### PR TITLE
Fixes type error in `cn` helper

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import { useState } from 'react';
@@ -57,4 +56,4 @@ export function CopyButton({ textToCopy, buttonSize = "icon", className }: CopyB
 
 // Helper to add cn if not already present
 import { cn as shadcnCn } from "@/lib/utils";
-const cn = (...inputs: any[]) => shadcnCn(inputs);
+const cn = (...inputs: any[]) => shadcnCn(...inputs);


### PR DESCRIPTION
Fixes a type error in the `cn` helper function.

- Updates the `cn` helper function to correctly pass arguments to the `shadcnCn` function.
- This resolves a potential type error and ensures proper class name concatenation.